### PR TITLE
JaxRsRequestFactory does not propagate all exceptions

### DIFF
--- a/client-jaxrs/src/main/java/io/github/ma1uta/matrix/client/factory/jaxrs/JaxRsRequestFactory.java
+++ b/client-jaxrs/src/main/java/io/github/ma1uta/matrix/client/factory/jaxrs/JaxRsRequestFactory.java
@@ -349,8 +349,10 @@ public class JaxRsRequestFactory implements RequestFactory {
     protected <R> void invokeAction(Supplier<CompletionStage<Response>> action, Function<Response, R> extractor,
                                     CompletableFuture<R> result, long delay) {
         action.get().handle((response, throwable) -> {
-            if (throwable != null)
-                throw new CompletionException(throwable);
+            if (throwable != null) {
+                result.completeExceptionally(throwable);
+                return null;
+            }
 
             try {
                 int status = response.getStatus();


### PR DESCRIPTION
Hi!

I've identified a potential issue in the source-code, while setting up a new plugin for Matrix on my bot platform, Manebot.  It appears as though JaxRsRequestFactory.invokeAction does not handle an exceptionally-completed future (produced by `action.get()`) in its handlers, as `thenAccept` does not handle exceptions.

I've changed that to `handle`, which still accepts `response`, but also accepts `throwable`, in case the `CompletableFuture` returned by `action.get()` has an issue.   Finally, I propagated the exception to `result` but completing that future exceptionally.  Now, any such exceptions are passed along to the future that is returned to calling integrators.

The issue stems from the fact that my Synapse server is actually on a non-trusted CA root, that is shared in my organization.  Therefore, it's not in the Java `cacerts` file, and Java does not trust it.  When I call `login()`, the PKIX error that is thrown is "lost", and `login().join()` hangs forever unfortunately.  Now, with the exception propagated, `join()` will receive the exception and I can both see, and handle this error.  I assume this would happen for connection refused, timeouts, etc. as well, which could severely reduce stability of the API.

However, with the exception propagation in place, it is possible for the caller to handle these.

I should add that I branched from `654b5c6b: Release 0.9.0` first, and that may cause some issues with this merge from GitHub's point of view.  On my fork, I have released this as a patch to 0.9, as 0.9.2.