### PR TITLE
Use parent POM version for versioning all sub-modules and their cross-dependencies

### DIFF
--- a/bot-impl/pom.xml
+++ b/bot-impl/pom.xml
@@ -26,17 +26,12 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>bot-impl</artifactId>
-    <version>0.10.0</version>
-
-    <properties>
-        <version.lib.client-impl>0.9.2-SNAPSHOT</version.lib.client-impl>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>client-impl</artifactId>
-            <version>${version.lib.client-impl}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/client-impl/pom.xml
+++ b/client-impl/pom.xml
@@ -26,16 +26,6 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>client-impl</artifactId>
-    <version>0.10.0</version>
-
-    <properties>
-        <version.lib.client-api>0.9.2-SNAPSHOT</version.lib.client-api>
-        <version.lib.common-impl>0.9.2-SNAPSHOT</version.lib.common-impl>
-        <version.lib.jackson-support>0.9.2-SNAPSHOT</version.lib.jackson-support>
-        <version.lib.logback-classic>1.2.3</version.lib.logback-classic>
-        <version.lib.resteasy>4.4.2.Final</version.lib.resteasy>
-        <version.lib.wiremock>2.26.0</version.lib.wiremock>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -45,12 +35,12 @@
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>client-api</artifactId>
-            <version>${version.lib.client-api}</version>
+            <version>${version.lib.jeon}</version>
         </dependency>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-impl</artifactId>
-            <version>${version.lib.common-impl}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -83,7 +73,7 @@
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>jackson-support</artifactId>
-            <version>${version.lib.jackson-support}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/common-impl/pom.xml
+++ b/common-impl/pom.xml
@@ -19,23 +19,19 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.github.ma1uta.matrix</groupId>
         <artifactId>jmsdk</artifactId>
         <version>0.10.0</version>
     </parent>
     <artifactId>common-impl</artifactId>
-    <version>0.10.0</version>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${version.lib.jeon}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>

--- a/jackson-support/pom.xml
+++ b/jackson-support/pom.xml
@@ -19,30 +19,24 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.github.ma1uta.matrix</groupId>
         <artifactId>jmsdk</artifactId>
         <version>0.10.0</version>
     </parent>
     <artifactId>jackson-support</artifactId>
-    <version>0.10.0</version>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-        <version.lib.common-impl>0.9.2-SNAPSHOT</version.lib.common-impl>
-        <version.lib.jaxb-api>2.3.1</version.lib.jaxb-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${version.lib.jeon}</version>
         </dependency>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-impl</artifactId>
-            <version>${version.lib.common-impl}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/jsonb-support/pom.xml
+++ b/jsonb-support/pom.xml
@@ -19,33 +19,24 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.github.ma1uta.matrix</groupId>
         <artifactId>jmsdk</artifactId>
         <version>0.10.0</version>
     </parent>
     <artifactId>jsonb-support</artifactId>
-    <version>0.10.0</version>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-        <version.lib.common-impl>0.9.2-SNAPSHOT</version.lib.common-impl>
-        <version.lib.jakarta.json-api>1.1.6</version.lib.jakarta.json-api>
-        <version.lib.yasson>1.0.6</version.lib.yasson>
-        <version.lib.mapstruct>1.3.1.Final</version.lib.mapstruct>
-        <version.lib.commons-beanutils>1.9.4</version.lib.commons-beanutils>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${version.lib.jeon}</version>
         </dependency>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-impl</artifactId>
-            <version>${version.lib.common-impl}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.json.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,16 +87,25 @@
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
 
         <!-- dependencies -->
+        <version.lib.jeon>0.10.0</version.lib.jeon>
+        <version.lib.commons-beanutils>1.9.4</version.lib.commons-beanutils>
+        <version.lib.logback-classic>1.2.3</version.lib.logback-classic>
         <version.lib.slf4j-api>1.7.30</version.lib.slf4j-api>
         <version.lib.jackson-databind>2.10.2</version.lib.jackson-databind>
         <version.lib.jackson-module-jaxb-annotations>2.10.2</version.lib.jackson-module-jaxb-annotations>
         <version.lib.jackson-jaxrs-json-provider>2.10.2.1</version.lib.jackson-jaxrs-json-provider>
+        <version.lib.jakarta.json-api>1.1.6</version.lib.jakarta.json-api>
         <version.lib.jakarta.persistence-api>2.2.3</version.lib.jakarta.persistence-api>
         <version.lib.junit-bom>5.6.0</version.lib.junit-bom>
         <version.lib.jersey-client>2.30</version.lib.jersey-client>
         <version.lib.jersey.hk2>2.30</version.lib.jersey.hk2>
         <version.lib.jersey-media-json-jackson>2.30</version.lib.jersey-media-json-jackson>
         <version.lib.microprofile>3.2</version.lib.microprofile>
+        <version.lib.mapstruct>1.3.1.Final</version.lib.mapstruct>
+        <version.lib.yasson>1.0.6</version.lib.yasson>
+        <version.lib.jaxb-api>2.3.1</version.lib.jaxb-api>
+        <version.lib.resteasy>4.4.2.Final</version.lib.resteasy>
+        <version.lib.wiremock>2.26.0</version.lib.wiremock>
 
         <version.lib.asm>7.3.1</version.lib.asm>
     </properties>


### PR DESCRIPTION
fix #7

I recommend using `mvn release:prepare` and `mvn release:clean` to avoid similar issues in the future. Also some basic job on Travis CI running just `mvn install` would uncover that.