### PR TITLE
Added explicit Export-Package instruction for common-impl

### DIFF
--- a/common-impl/pom.xml
+++ b/common-impl/pom.xml
@@ -78,6 +78,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <Export-Package>io.github.ma1uta.matrix.*</Export-Package>
                         <Automatic-Module-Name>matrix.common.impl</Automatic-Module-Name>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
By default any packages containing 'impl' are excluded:
https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#default-behavior

Added explicit export instruction since `client-impl` depends on it.

Fixes #18