### PR TITLE
OSGi: added capability headers to MANIFEST.MF to support SPI

### DIFF
--- a/client-impl/pom.xml
+++ b/client-impl/pom.xml
@@ -109,6 +109,11 @@
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>matrix.client.impl</Automatic-Module-Name>
+                        <Require-Capability>
+                            osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)",
+                            osgi.serviceloader; filter:="(osgi.serviceloader=io.github.ma1uta.matrix.impl.Deserializer)",
+                            osgi.serviceloader; filter:="(osgi.serviceloader=io.github.ma1uta.matrix.impl.RestClientBuilderConfigurer)"
+                        </Require-Capability>
                     </instructions>
                 </configuration>
             </plugin>

--- a/jackson-support/pom.xml
+++ b/jackson-support/pom.xml
@@ -99,6 +99,14 @@
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>matrix.support.jackson</Automatic-Module-Name>
+                        <Require-Capability>
+                            osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)",
+                            osgi.serviceloader; filter:="(osgi.serviceloader=io.github.ma1uta.matrix.support.jackson.ObjectMapperProvider)"; resolution:=optional
+                        </Require-Capability>
+                        <Provide-Capability>
+                            osgi.serviceloader; osgi.serviceloader=io.github.ma1uta.matrix.impl.Deserializer,
+                            osgi.serviceloader; osgi.serviceloader=io.github.ma1uta.matrix.impl.RestClientBuilderConfigurer
+                        </Provide-Capability>
                     </instructions>
                 </configuration>
             </plugin>

--- a/jsonb-support/pom.xml
+++ b/jsonb-support/pom.xml
@@ -98,6 +98,14 @@
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>matrix.support.jsonb</Automatic-Module-Name>
+                        <Require-Capability>
+                            osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)",
+                            osgi.serviceloader; filter:="(osgi.serviceloader=io.github.ma1uta.matrix.support.jsonb.JsonbProvider)"; resolution:=optional
+                        </Require-Capability>
+                        <Provide-Capability>
+                            osgi.serviceloader; osgi.serviceloader=io.github.ma1uta.matrix.impl.Deserializer,
+                            osgi.serviceloader; osgi.serviceloader=io.github.ma1uta.matrix.impl.RestClientBuilderConfigurer
+                        </Provide-Capability>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Implementation:
* Enabled the OSGi ServiceLoader Mediator facility
* Added Provide-Capability headers for SPI providers
  * [Jackson](https://github.com/ma1uta/jmsdk/tree/master/jackson-support/src/main/resources/META-INF/services)
  * [JSON-B](https://github.com/ma1uta/jmsdk/tree/master/jsonb-support/src/main/resources/META-INF/services)
* Added Require-Capability headers for [SPI consumers](https://github.com/ma1uta/jmsdk/search?q=.load%28)
  * Right now only one provider bundle is allowed, so *either* `jackson-support` *or* `jsonb-support` can be used. Not both. Please let me know if this is wrong and I'll add support for simultaneous providers.
* Kept JSON provider requirements optional (default fallbacks available)
  * [`ObjectMapperProvider`](https://github.com/ma1uta/jmsdk/blob/master/jackson-support/src/main/java/io/github/ma1uta/matrix/support/jackson/ObjectMapperProvider.java#L36)
  * [`JsonbProvider`](https://github.com/ma1uta/jmsdk/blob/master/jsonb-support/src/main/java/io/github/ma1uta/matrix/support/jsonb/JsonbProvider.java#L35)

Background:
* `java.util.ServiceLoader.load()` [isn't directly supported](https://blog.osgi.org/2013/02/javautilserviceloader-in-osgi.html) in OSGi environments
* OSGi specifies a [ServiceLoader Mediator](https://docs.osgi.org/specification/osgi.enterprise/7.0.0/service.loader.html) which adds SPI support
* Apache Aries [SPI Fly](https://aries.apache.org/modules/spi-fly.html) is the current reference implementation
* All configuration is done via `MANIFEST.MF` headers
