### PR TITLE
Fix errors reported by Checkstyle

### DIFF
--- a/client-impl/src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java
+++ b/client-impl/src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java
@@ -23,7 +23,6 @@ import io.github.ma1uta.matrix.client.methods.blocked.AccountMethods;
 import io.github.ma1uta.matrix.client.methods.blocked.AuthMethods;
 import io.github.ma1uta.matrix.client.model.auth.LoginResponse;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,7 +51,7 @@ public class StandaloneClient extends MatrixClient {
      */
     public AuthAsyncMethods authAsync() {
         return getMethod(AuthAsyncMethods.class,
-                () -> new AuthAsyncMethods(getClientBuilder(), this::afterLogin, this::afterLogout));
+            () -> new AuthAsyncMethods(getClientBuilder(), this::afterLogin, this::afterLogout));
     }
 
     /**
@@ -62,7 +61,7 @@ public class StandaloneClient extends MatrixClient {
      */
     public AuthMethods auth() {
         return getMethod(AuthMethods.class,
-                () -> new AuthMethods(getClientBuilder(), this::afterLogin, this::afterLogout));
+            () -> new AuthMethods(getClientBuilder(), this::afterLogin, this::afterLogout));
     }
 
     /**
@@ -73,7 +72,7 @@ public class StandaloneClient extends MatrixClient {
     @Override
     public AccountAsyncMethods accountAsync() {
         return getMethod(AccountAsyncMethods.class,
-                () -> new AccountAsyncMethods(getClientBuilder(), this::afterLogin));
+            () -> new AccountAsyncMethods(getClientBuilder(), this::afterLogin));
     }
 
     /**


### PR DESCRIPTION
```
[INFO] --- maven-checkstyle-plugin:3.1.1:check (checkstyle) @ client-impl ---
[INFO] There are 4 errors reported by Checkstyle 8.35 with config/checkstyle/checkstyle.xml ruleset.
[ERROR] src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java:[26,8] (imports) UnusedImports: Unused import - java.util.concurrent.ExecutionException.
[ERROR] src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java:[55,17] (indentation) Indentation: 'lambda arguments' has incorrect indentation level 16, expected level should be 12.
[ERROR] src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java:[65,17] (indentation) Indentation: 'lambda arguments' has incorrect indentation level 16, expected level should be 12.
[ERROR] src/main/java/io/github/ma1uta/matrix/client/StandaloneClient.java:[76,17] (indentation) Indentation: 'lambda arguments' has incorrect indentation level 16, expected level should be 12.
```