### PR TITLE
Remove duplicate dependency

### DIFF
--- a/common-impl/pom.xml
+++ b/common-impl/pom.xml
@@ -65,10 +65,6 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.github.ma1uta.matrix</groupId>
-            <artifactId>common-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
```
[WARNING] Some problems were encountered while building the effective model for io.github.ma1uta.matrix:common-impl:jar:0.13.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.github.ma1uta.matrix:common-api:jar -> duplicate declaration of version (?) @ line 68, column 21
```